### PR TITLE
Make FA restrictions more informative

### DIFF
--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -75,8 +75,10 @@ class FurAffinityGenerator : QuickviewGenerator() {
         )
     }
 
-    private val submissionUrlRegex =
-        Regex("(furaffinity.net/view/(\\d{8}))|(d.facdn.net/art/(\\w*)/(\\d{10}))", RegexOption.IGNORE_CASE)
+    private val submissionUrlRegex = Regex(
+        "(furaffinity.net/(?:full|view)/(\\d+))|(d\\.(?:facdn|furaffinity).net/art/(\\w*)/(\\d+))",
+        RegexOption.IGNORE_CASE
+    )
 
     override suspend fun generate(event: MessageReceivedEvent, config: QuickviewConfig): Flow<MessageEmbed> =
         if (config.furaffinityEnabled) findIds(event.message.contentRaw).mapNotNull {

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -81,11 +81,12 @@ class FurAffinityGenerator : QuickviewGenerator() {
     override suspend fun generate(event: MessageReceivedEvent, config: QuickviewConfig): Flow<MessageEmbed> =
         if (config.furaffinityEnabled) findIds(event.message.contentRaw).mapNotNull {
             getSubmission(it)?.run {
-                // allow only SFW thumbnails in DMs, and all in enabled servers but only show NSFW in NSFW channels
-                val allowThumbnail = (!event.isFromGuild && !rating.nsfw) ||
-                        (config.furaffinityThumbnails && (event.textChannel.isNSFW || !rating.nsfw))
+                // allow NSFW quickviews only in NSFW channels, never SFW channels or DMs
+                val nsfwAllowed = event.isFromGuild && event.textChannel.isNSFW
+                // allow thumbnails in DMs and in enabled servers
+                val thumbnailAllowed = !event.isFromGuild || config.furaffinityThumbnails
 
-                getEmbed(allowThumbnail)
+                getEmbed(nsfwAllowed, thumbnailAllowed)
             }
         } else emptyFlow()
 

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
@@ -64,11 +64,11 @@ data class Submission(
     /**
      * Download URL of the content
      */
-    val download: String,
+    val download: String?,
     /**
      * URL of the full resolution content
      */
-    val full: String,
+    val full: String?,
     /**
      * Category the submission is placed under
      */
@@ -125,7 +125,7 @@ data class Submission(
         val description = SimpleDescriptionBuilder()
 
         // Add the different fields to the quickview embed description
-        description.addField("Category", "$category - $theme (${rating.name})")
+        description.addField("Category", "$category / $theme (${rating.name})")
         species?.let { description.addField("Species", it) }
         gender?.let { description.addField("Gender", it) }
         description.addField(null, "**Favorites** $favorites | **Comments** $comments | **Views** $views")
@@ -138,8 +138,11 @@ data class Submission(
                 embed.setImage(full)
             }
 
-            val fileType = download.substringAfterLast(".")
-            description.addField("Download", "[${resolution ?: fileType}]($download)")
+            if (download != null) {
+                val fileType = download.substringAfterLast(".")
+                val downloadText = if (resolution != null) "$resolution (.$fileType)" else fileType
+                description.addField("Download", "[$downloadText]($download)")
+            }
 
             val linkedKeywords = keywords.joinToString { "[$it](https://www.furaffinity.net/search/@keywords%20$it)" }
             val fancyKeywords = if (linkedKeywords.length < MessageEmbed.VALUE_MAX_LENGTH) {

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
@@ -114,34 +114,43 @@ data class Submission(
     /**
      * Creates an embed with the submission's info and a thumbnail if desired
      */
-    fun getEmbed(thumbnail: Boolean): MessageEmbed {
-        val linkedKeywords = keywords.joinToString { "[$it](https://www.furaffinity.net/search/@keywords%20$it)" }
-        val fancyKeywords = if (linkedKeywords.length < MessageEmbed.VALUE_MAX_LENGTH) {
-            linkedKeywords
-        } else {
-            keywords.joinToString(limit = MessageEmbed.VALUE_MAX_LENGTH)
-        }
-        val fileType = download.substringAfterLast(".")
-        val description = SimpleDescriptionBuilder()
-
-        // Add the different fields to the quickview embed description
-        description.addField("Category", "$category - $theme (${rating.name})")
-        species?.let { description.addField("Species", it) }
-        gender?.let { description.addField("Gender", it) }
-        description.addField(null, "**Favorites** $favorites | **Comments** $comments | **Views** $views")
-        if ((thumbnail && rating.nsfw) || !rating.nsfw) {
-            description.addField("Download", "[${resolution ?: fileType}]($download)")
-        }
-
-        return EmbedBuilder()
-            .setTitle(title, link)
-            .setImage(if (thumbnail) full else null)
-            .setDescription(description.build())
-            .addField("Keywords", fancyKeywords, false)
+    fun getEmbed(nsfwAllowed: Boolean, thumbnailAllowed: Boolean): MessageEmbed {
+        val embed = EmbedBuilder()
             .setFooter("FurAffinity")
             .setColor(rating.color)
             .setAuthor(name, profile, avatar)
             .setTimestamp(Instant.parse(postedAt))
-            .build()
+
+        if (rating.nsfw && !nsfwAllowed) {
+            embed.setDescription("Submissions with a rating of $rating cannot be previewed outside of a NSFW channel!")
+        } else {
+            val linkedKeywords = keywords.joinToString { "[$it](https://www.furaffinity.net/search/@keywords%20$it)" }
+            val fancyKeywords = if (linkedKeywords.length < MessageEmbed.VALUE_MAX_LENGTH) {
+                linkedKeywords
+            } else {
+                keywords.joinToString(limit = MessageEmbed.VALUE_MAX_LENGTH)
+            }
+            val fileType = download.substringAfterLast(".")
+            val description = SimpleDescriptionBuilder()
+
+            // Add the different fields to the quickview embed description
+            description.addField("Category", "$category - $theme (${rating.name})")
+            species?.let { description.addField("Species", it) }
+            gender?.let { description.addField("Gender", it) }
+            description.addField(null, "**Favorites** $favorites | **Comments** $comments | **Views** $views")
+            description.addField("Download", "[${resolution ?: fileType}]($download)")
+
+            if (thumbnailAllowed) {
+                embed.setImage(full)
+            }
+
+            embed
+                .setTitle(title, link)
+                .setDescription(description.build())
+                .addField("Keywords", fancyKeywords, false)
+                .build()
+        }
+
+        return embed.build()
     }
 }

--- a/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
+++ b/bot/src/main/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/Submission.kt
@@ -116,41 +116,41 @@ data class Submission(
      */
     fun getEmbed(nsfwAllowed: Boolean, thumbnailAllowed: Boolean): MessageEmbed {
         val embed = EmbedBuilder()
-            .setFooter("FurAffinity")
-            .setColor(rating.color)
             .setAuthor(name, profile, avatar)
+            .setTitle(title, link)
+            .setColor(rating.color)
+            .setFooter("FurAffinity")
             .setTimestamp(Instant.parse(postedAt))
 
+        val description = SimpleDescriptionBuilder()
+
+        // Add the different fields to the quickview embed description
+        description.addField("Category", "$category - $theme (${rating.name})")
+        species?.let { description.addField("Species", it) }
+        gender?.let { description.addField("Gender", it) }
+        description.addField(null, "**Favorites** $favorites | **Comments** $comments | **Views** $views")
+
         if (rating.nsfw && !nsfwAllowed) {
-            embed.setDescription("Submissions with a rating of $rating cannot be previewed outside of a NSFW channel!")
+            val warningText = "Submissions with a rating of $rating cannot be previewed outside of a NSFW channel!"
+            embed.addField("Warning", warningText, false)
         } else {
+            if (thumbnailAllowed) {
+                embed.setImage(full)
+            }
+
+            val fileType = download.substringAfterLast(".")
+            description.addField("Download", "[${resolution ?: fileType}]($download)")
+
             val linkedKeywords = keywords.joinToString { "[$it](https://www.furaffinity.net/search/@keywords%20$it)" }
             val fancyKeywords = if (linkedKeywords.length < MessageEmbed.VALUE_MAX_LENGTH) {
                 linkedKeywords
             } else {
                 keywords.joinToString(limit = MessageEmbed.VALUE_MAX_LENGTH)
             }
-            val fileType = download.substringAfterLast(".")
-            val description = SimpleDescriptionBuilder()
 
-            // Add the different fields to the quickview embed description
-            description.addField("Category", "$category - $theme (${rating.name})")
-            species?.let { description.addField("Species", it) }
-            gender?.let { description.addField("Gender", it) }
-            description.addField(null, "**Favorites** $favorites | **Comments** $comments | **Views** $views")
-            description.addField("Download", "[${resolution ?: fileType}]($download)")
-
-            if (thumbnailAllowed) {
-                embed.setImage(full)
-            }
-
-            embed
-                .setTitle(title, link)
-                .setDescription(description.build())
-                .addField("Keywords", fancyKeywords, false)
-                .build()
+            embed.addField("Keywords", fancyKeywords, false)
         }
 
-        return embed.build()
+        return embed.setDescription(description.build()).build()
     }
 }

--- a/bot/src/test/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGeneratorTest.kt
+++ b/bot/src/test/kotlin/me/ianmooreis/glyph/bot/messaging/quickview/furaffinity/FurAffinityGeneratorTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertNotNull
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 /**
@@ -53,16 +54,17 @@ internal class FurAffinityGeneratorTest {
     @Test
     fun `should find distinct ids in a message`() = runBlocking {
         // a regular message
-        assert(generator.findIds("nothing of substance example.net/view/12345").count() == 0)
+        assertEquals(0, generator.findIds("nothing of substance example.net/view/12345").count())
         // a message with a submission url
-        assert(generator.findIds("https://www.furaffinity.net/view/12239491/").first() == 12239491)
+        assertEquals(12239491, generator.findIds("https://www.furaffinity.net/view/12239491/").first())
         // there should be no duplicates
-        assert(
+        assertEquals(
+            2,
             generator.findIds(
                 "https://www.furaffinity.net/view/12239491/ " +
                         "http://www.furaffinity.net/view/9719932/ " +
                         "furaffinity.net/view/12239491/"
-            ).count() == 2
+            ).count()
         )
     }
 
@@ -82,13 +84,16 @@ internal class FurAffinityGeneratorTest {
 
         assertNotNull(submission)
 
-        assert(submission?.title == "Applied Sciences Units 01 and 02")
-        assert(submission?.name == "Fender")
-        assert(submission?.download == "https://d.facdn.net/art/fender/1358541618/1358541618.fender_kiryu_promoart.jpg")
+        assertEquals("Applied Sciences Units 01 and 02", submission?.title)
+        assertEquals("Fender", submission?.name)
+        assertEquals(
+            "https://d.furaffinity.net/art/fender/1358541618/1358541618.fender_kiryu_promoart.jpg",
+            submission?.download
+        )
         assert(submission?.keywords?.containsAll(listOf("mecha", "robots", "rednef")) ?: false)
-        assert(submission?.gender == "Other / Not Specified")
-        assert(submission?.resolution == "900x643")
-        assert(submission?.rating == SubmissionRating.General)
+        assertEquals("Other / Not Specified", submission?.gender)
+        assertEquals("900x643", submission?.resolution)
+        assertEquals(SubmissionRating.General, submission?.rating)
     }
 
     @Test


### PR DESCRIPTION
This includes some changes requested by a friend who actively uses FA Quickviews, including a descriptive warning why NSFW content is not shown outside of NSFW channels.