### PR TITLE
Tidy up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 [![GitHub](https://img.shields.io/github/license/glyph-discord/glyph.kt)](https://github.com/glyph-discord/glyph.kt/blob/master/LICENSE)
 [![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/glyph-discord/glyph.kt/Java%20CI/master)](https://github.com/glyph-discord/glyph.kt/actions)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/60f13f47ba0d427a84ea713b0f8897a8)](https://app.codacy.com/app/IanMooreIsMe/glyph-kotlin?utm_source=github.com&utm_medium=referral&utm_content=glyph-discord/glyph-kotlin&utm_campaign=Badge_Grade_Settings)
 [![Discord Bots](https://discordbots.org/api/widget/status/248186527161516032.svg?noavatar=true)](https://discordbots.org/bot/248186527161516032)
 [![Discord Bots](https://discordbots.org/api/widget/servers/248186527161516032.svg?noavatar=true)](https://discordbots.org/bot/248186527161516032)
 
-# glyph-kotlin
+# glyph.kt
+
 The Kotlin rewrite of the Glyph Discord bot
 
-Glyph is an experimental Discord bot that makes use of [DialogFlow](https://dialogflow.com/) to attempt to understand and process natural language requests as opposed to a traditional command based bot.
+Glyph is an experimental Discord bot that uses [DialogFlow](https://dialogflow.com/) to attempt to understand and process natural language requests as opposed to a traditional command based bot.
 
 To learn more about how to use Glyph, check out the documentation [here](https://gl.yttr.org/).
 
 ## Self Hosting
 
-In order to host your own copy of Glyph, some set up will be required. 
+In order to host your own copy of Glyph, some set up will be required.
+
 This will be further documented in detail later, but the basic idea is that you will need to create and train an agent on DialogFlow to respond to different prompts, and set all the needed environmental variables used in the code.


### PR DESCRIPTION
Codacy is no longer used and Kotlin should not be part of the name of the project. However the ".kt" seems fine. 

https://kotlinlang.org/docs/guidelines.html

In making this change I accidentally pushed to master, since I did this on my phone. I've updated the branch rule to hopefully prevent that from ever happening again. The commit was undone and force pushed the fix. 