### PR TITLE
Enhance FA Quickviews

### DIFF
--- a/glyph-bot/build.gradle.kts
+++ b/glyph-bot/build.gradle.kts
@@ -22,6 +22,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 import tanvd.kosogor.proxy.shadowJar
 
 /*
@@ -69,6 +70,12 @@ shadowJar {
 
 tasks.named("stage") {
     dependsOn("shadowJar")
+}
+
+tasks.withType(KotlinJvmCompile::class) {
+    kotlinOptions {
+        freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
+    }
 }
 
 dependencies {

--- a/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewDirector.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewDirector.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.requests.restaction.MessageAction
 import org.yttr.glyph.bot.Director
@@ -58,6 +60,8 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
     private val generators = setOf(PicartoGenerator(), FurAffinityGenerator())
     private val generatorTimeout = Duration.ofSeconds(GENERATOR_TIMEOUT_SECONDS).toMillis()
 
+    private data class EmbedFold(val replyMessage: Message? = null, val embeds: List<MessageEmbed> = emptyList())
+
     /**
      * Check for quickviews when a message is received
      */
@@ -69,15 +73,29 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
         launch {
             withTimeout(generatorTimeout) {
                 generators.map { it.generate(event, config.quickview) }.merge().take(EMBED_LIMIT)
-                    .fold(event.messageId) { messageId, embed ->
-                        if (messageId == event.messageId) {
-                            event.message.suppressEmbeds(true).reason("Quickview").queue({}) {
-                                log.debug("Unable to suppress embeds for Quickviews in context ${event.contextHash}")
+                    .fold(EmbedFold()) { (message, embeds), newEmbed ->
+                        when {
+                            message == null -> {
+                                event.message.suppressEmbeds(true).reason("Quickview").queue({}) {
+                                    log.debug(
+                                        "Unable to suppress embeds for Quickviews in context ${event.contextHash}"
+                                    )
+                                }
+                                val replyMessage = event.message.replyEmbeds(newEmbed)
+                                    .mentionRepliedUser(false)
+                                    .await()
+                                messagingDirector.trackVolatile(event.messageId, replyMessage.id)
+                                EmbedFold(replyMessage, listOf(newEmbed))
+                            }
+                            !embeds.contains(newEmbed) -> {
+                                val newEmbeds = embeds.plus(newEmbed)
+                                message.editMessageEmbeds(newEmbeds).queue()
+                                EmbedFold(message, newEmbeds)
+                            }
+                            else -> {
+                                EmbedFold(message, embeds)
                             }
                         }
-                        val responseId = event.channel.sendMessage(embed).await().id
-                        messagingDirector.trackVolatile(messageId, responseId)
-                        responseId
                     }
             }
         }

--- a/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewDirector.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewDirector.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -24,7 +24,10 @@
 
 package org.yttr.glyph.bot.messaging.quickview
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.fold
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
@@ -44,7 +47,12 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
         /**
          * The maximum amount of time the generators are allowed to process a message for
          */
-        const val GENERATOR_TIMEOUT_SECONDS: Long = 15
+        private const val GENERATOR_TIMEOUT_SECONDS: Long = 15
+
+        /**
+         * Maximum number of embeds that should be generated
+         */
+        private const val EMBED_LIMIT: Int = 5
     }
 
     private val generators = setOf(PicartoGenerator(), FurAffinityGenerator())
@@ -53,14 +61,15 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
     /**
      * Check for quickviews when a message is received
      */
+    @OptIn(ExperimentalCoroutinesApi::class)
     override fun onMessageReceived(event: MessageReceivedEvent) {
         if (event.isIgnorable) return
         val config = if (event.channelType.isGuild) event.guild.config else configDirector.defaultConfig
 
         launch {
             withTimeout(generatorTimeout) {
-                generators.forEach {
-                    it.generate(event, config.quickview).fold(event.messageId) { messageId, embed ->
+                generators.map { it.generate(event, config.quickview) }.merge().take(EMBED_LIMIT)
+                    .fold(event.messageId) { messageId, embed ->
                         if (messageId == event.messageId) {
                             event.message.suppressEmbeds(true).reason("Quickview").queue({}) {
                                 log.debug("Unable to suppress embeds for Quickviews in context ${event.contextHash}")
@@ -70,7 +79,6 @@ class QuickviewDirector(private val messagingDirector: MessagingDirector) : Dire
                         messagingDirector.trackVolatile(messageId, responseId)
                         responseId
                     }
-                }
             }
         }
     }

--- a/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewGenerator.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/QuickviewGenerator.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.Json
 import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.yttr.glyph.shared.config.server.QuickviewConfig
 import java.io.Closeable
 
@@ -38,6 +40,11 @@ import java.io.Closeable
  * Handle extract data from websites to build relevant QuickViews
  */
 abstract class QuickviewGenerator : Closeable {
+    /**
+     * Logger
+     */
+    protected val log: Logger = LoggerFactory.getLogger(this.javaClass.simpleName)
+
     /**
      * HTTP client for making API requests
      */

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -49,13 +49,15 @@ class FurAffinityGenerator : QuickviewGenerator() {
         private const val GALLERY_LISTING_SIZE: Int = 72
 
         private val submissionUrlRegex = Regex(
-            "(furaffinity.net/(?:full|view)/(\\d+))|(d\\.(?:facdn|furaffinity).net/art/(\\w*)/(\\d+))",
+            "\\b(furaffinity.net/(?:full|view)/(\\d+))|(d\\.(?:facdn|furaffinity).net/art/([\\w-]+)/(\\d+))\\b",
             RegexOption.IGNORE_CASE
         )
 
         private const val SUBMISSION_URL_REGEX_SUBMISSION_ID_GROUP: Int = 2
         private const val SUBMISSION_URL_REGEX_CDN_ID_GROUP: Int = 5
         private const val SUBMISSION_URL_REGEX_USERNAME_GROUP: Int = 4
+
+        private val escapedLinkRegex = Regex("<\\S+>")
 
         /**
          * Represents a user page in the API
@@ -102,7 +104,7 @@ class FurAffinityGenerator : QuickviewGenerator() {
      * Attempts to find ids associated with FurAffinity submissions, if there are any
      */
     fun findIds(content: String): Flow<Int> =
-        submissionUrlRegex.findAll(content).map {
+        submissionUrlRegex.findAll(content.replace(escapedLinkRegex, "")).map {
             val submissionId = it.groups[SUBMISSION_URL_REGEX_SUBMISSION_ID_GROUP]?.value?.toInt()
             val cdnId = it.groups[SUBMISSION_URL_REGEX_CDN_ID_GROUP]?.value?.toInt()
             val username = it.groups[SUBMISSION_URL_REGEX_USERNAME_GROUP]?.value

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -48,6 +48,15 @@ class FurAffinityGenerator : QuickviewGenerator() {
         private const val API_BASE: String = "https://faexport.spangle.org.uk"
         private const val GALLERY_LISTING_SIZE: Int = 72
 
+        private val submissionUrlRegex = Regex(
+            "(furaffinity.net/(?:full|view)/(\\d+))|(d\\.(?:facdn|furaffinity).net/art/(\\w*)/(\\d+))",
+            RegexOption.IGNORE_CASE
+        )
+
+        private const val SUBMISSION_URL_REGEX_SUBMISSION_ID_GROUP: Int = 2
+        private const val SUBMISSION_URL_REGEX_CDN_ID_GROUP: Int = 5
+        private const val SUBMISSION_URL_REGEX_USERNAME_GROUP: Int = 4
+
         /**
          * Represents a user page in the API
          */
@@ -75,11 +84,6 @@ class FurAffinityGenerator : QuickviewGenerator() {
         )
     }
 
-    private val submissionUrlRegex = Regex(
-        "(furaffinity.net/(?:full|view)/(\\d+))|(d\\.(?:facdn|furaffinity).net/art/(\\w*)/(\\d+))",
-        RegexOption.IGNORE_CASE
-    )
-
     override suspend fun generate(event: MessageReceivedEvent, config: QuickviewConfig): Flow<MessageEmbed> =
         if (config.furaffinityEnabled) findIds(event.message.contentRaw).mapNotNull {
             getSubmission(it)?.run {
@@ -92,18 +96,21 @@ class FurAffinityGenerator : QuickviewGenerator() {
             }
         } else emptyFlow()
 
+    private data class SubmissionUrlData(val submissionId: Int?, val cdnId: Int?, val username: String?)
+
     /**
      * Attempts to find ids associated with FurAffinity submissions, if there are any
      */
     fun findIds(content: String): Flow<Int> =
-        submissionUrlRegex.findAll(content).distinct().asFlow().mapNotNull {
-            val submissionId = it.groups[2]?.value?.toInt()
-            val cdnId = it.groups[5]?.value?.toInt()
-            val username = it.groups[4]?.value
-
+        submissionUrlRegex.findAll(content).map {
+            val submissionId = it.groups[SUBMISSION_URL_REGEX_SUBMISSION_ID_GROUP]?.value?.toInt()
+            val cdnId = it.groups[SUBMISSION_URL_REGEX_CDN_ID_GROUP]?.value?.toInt()
+            val username = it.groups[SUBMISSION_URL_REGEX_USERNAME_GROUP]?.value
+            SubmissionUrlData(submissionId, cdnId, username)
+        }.distinct().asFlow().mapNotNull {
             when {
-                submissionId != null -> submissionId
-                cdnId != null && username != null -> findSubmissionId(cdnId, username)
+                it.submissionId != null -> it.submissionId
+                it.cdnId != null && it.username != null -> findSubmissionId(it.cdnId, it.username)
                 else -> null
             }
         }
@@ -142,6 +149,7 @@ class FurAffinityGenerator : QuickviewGenerator() {
             url.takeFrom(API_BASE).path("submission", "$id.json")
         }
     } catch (e: ClientRequestException) {
+        log.debug("Error getting submission data", e)
         null
     }
 }

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -57,7 +57,7 @@ class FurAffinityGenerator : QuickviewGenerator() {
         private const val SUBMISSION_URL_REGEX_CDN_ID_GROUP: Int = 5
         private const val SUBMISSION_URL_REGEX_USERNAME_GROUP: Int = 4
 
-        private val escapedLinkRegex = Regex("<\\S+>")
+        private val escapedLinkRegex = Regex("<\\S+>|`.+`", RegexOption.DOT_MATCHES_ALL)
 
         /**
          * Represents a user page in the API

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/SubmissionRating.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/SubmissionRating.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -42,15 +42,15 @@ enum class SubmissionRating(
     /**
      * Suitable for all-ages
      */
-    General(Color.GREEN, false),
+    General(Color.decode("#79A977"), false),
 
     /**
      * Gore, violence or tasteful/artistic nudity or mature themes.
      */
-    Mature(Color.BLUE, true),
+    Mature(Color.decode("#697CC1"), true),
 
     /**
      * Explicit or imagery otherwise geared towards adult audiences.
      */
-    Adult(Color.RED, true)
+    Adult(Color.decode("#992D22"), true)
 }

--- a/glyph-bot/src/test/kotlin/messaging/quickview/furaffinity/FurAffinityGeneratorTest.kt
+++ b/glyph-bot/src/test/kotlin/messaging/quickview/furaffinity/FurAffinityGeneratorTest.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -24,7 +24,6 @@
 
 package org.yttr.glyph.bot.messaging.quickview.furaffinity
 
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -38,10 +37,10 @@ import kotlin.test.assertNull
  *
  * All tests use the "Fender" mascot account
  */
+@Suppress("HttpUrlsUsage")
 internal class FurAffinityGeneratorTest {
     private val generator = FurAffinityGenerator()
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `should find submission id from CDN id`() = runBlocking {
         // https://www.furaffinity.net/view/4483888/
@@ -50,7 +49,6 @@ internal class FurAffinityGeneratorTest {
         assert(submissionId == 4483888)
     }
 
-    @ExperimentalCoroutinesApi
     @Test
     fun `should find distinct ids in a message`() = runBlocking {
         // a regular message

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,32 @@
+#
+# gradle.properties
+#
+# Glyph, a Discord bot that uses natural language instead of commands
+# powered by DialogFlow and Kotlin
+#
+# Copyright (C) 2017-2021 by Ian Moore
+#
+# This file is part of Glyph.
+#
+# Glyph is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
 # suppress inspection "UnusedProperty" for whole file
 kotlin.code.style=official
 kotlinVersion=1.5.10
 coroutinesVersion=1.5.0
-jdaVersion=4.2.1_272
+jdaVersion=4.3.0_295
 logbackVersion=1.2.1
 exposedVersion=0.20.1
 ktorVersion=1.6.0


### PR DESCRIPTION
This little night of changes with @Offline-User includes multiple "much needed fixes":

- [x] Regular and CDN urls should not generate duplicate embeds 
- [x] Embeds should be limited to 5 max (closes #52)
- [x] The embed color strip should be changed to less harsh colors (closes #51)
- [x] Links inside of <> should be ignored
- [x] It should be clear why Glyph made this message (uses reply feature)
- [x] Glyph should only send a single message

This does not yet address editing messages that contain FA links.