### PR TITLE
Use reply to indicate skill invoker

### DIFF
--- a/glyph-bot/src/main/kotlin/messaging/MessagingDirector.kt
+++ b/glyph-bot/src/main/kotlin/messaging/MessagingDirector.kt
@@ -181,7 +181,11 @@ class MessagingDirector(
         val message = MessageBuilder().setContent(content?.trim()).setEmbeds(embed).build()
         // try to send the message
         try {
-            this.reply(message).mentionRepliedUser(false).queue {
+            if (isFromGuild) {
+                reply(message).mentionRepliedUser(false)
+            } else {
+                channel.sendMessage(message)
+            }.queue {
                 if (ttl != null) {
                     it.delete().queueAfter(ttl.seconds, TimeUnit.SECONDS)
                 } else if (volatile) {
@@ -189,7 +193,7 @@ class MessagingDirector(
                 }
             }
         } catch (e: InsufficientPermissionException) {
-            logSendFailure(this.textChannel, e)
+            logSendFailure(textChannel, e)
         }
     }
 }

--- a/glyph-bot/src/main/kotlin/messaging/MessagingDirector.kt
+++ b/glyph-bot/src/main/kotlin/messaging/MessagingDirector.kt
@@ -98,11 +98,8 @@ class MessagingDirector(
      * @param channel the channel where the message failed to send
      */
     private fun logSendFailure(channel: TextChannel, exception: Exception) {
-        if (channel.type.isGuild) {
-            log.warn("Failed to send message in $channel of ${channel.guild}!", exception)
-        } else {
-            log.warn("Failed to send message in $channel!.", exception)
-        }
+        val warningSuffix = if (channel.type.isGuild) " of ${channel.guild}!" else "!"
+        log.warn("Failed to send message in $channel$warningSuffix", exception)
     }
 
     /**
@@ -117,7 +114,7 @@ class MessagingDirector(
         val ai = try {
             aiAgent.request(event.message.contentClean, event.contextHash)
         } catch (e: IllegalArgumentException) {
-            log.trace("DialogFlow error", e)
+            log.trace("${aiAgent.name} error", e)
             message.addReaction("⁉").queue()
             return
         }

--- a/glyph-bot/src/main/kotlin/messaging/Response.kt
+++ b/glyph-bot/src/main/kotlin/messaging/Response.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -24,6 +24,8 @@
 
 package org.yttr.glyph.bot.messaging
 
+import net.dv8tion.jda.api.MessageBuilder
+import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageEmbed
 import java.time.Duration
 
@@ -31,24 +33,42 @@ import java.time.Duration
  * A way Glyph can respond to a message
  */
 sealed class Response {
+    /**
+     * A message type response
+     */
+    abstract class MessageResponse : Response() {
+        /**
+         * The message content
+         */
+        abstract val content: String?
+
+        /**
+         * The message embed
+         */
+        abstract val embed: MessageEmbed?
+
+        /**
+         * JDA message
+         */
+        val message: Message by lazy {
+            val builder = MessageBuilder()
+            content?.let { builder.setContent(it.trim()) }
+            embed?.let { builder.setEmbeds(it) }
+            builder.build()
+        }
+    }
 
     /**
      * A response that only lasts a limited about of time
      */
     data class Ephemeral(
-        /**
-         * The message content
-         */
-        val content: String? = null,
-        /**
-         * The message embed
-         */
-        val embed: MessageEmbed? = null,
+        override val content: String? = null,
+        override val embed: MessageEmbed? = null,
         /**
          * The time to live for the message before being deleted
          */
         val ttl: Duration
-    ) : Response() {
+    ) : MessageResponse() {
         constructor(content: String, ttl: Duration) : this(content, null, ttl)
         constructor(embed: MessageEmbed, ttl: Duration) : this(null, embed, ttl)
     }
@@ -57,15 +77,9 @@ sealed class Response {
      * A message that will delete itself when the triggering message is also deleted
      */
     data class Volatile(
-        /**
-         * The message content
-         */
-        val content: String? = null,
-        /**
-         * The message embed
-         */
-        val embed: MessageEmbed? = null
-    ) : Response() {
+        override val content: String? = null,
+        override val embed: MessageEmbed? = null
+    ) : MessageResponse() {
         constructor(embed: MessageEmbed) : this(null, embed)
     }
 
@@ -73,15 +87,9 @@ sealed class Response {
      * A message that will not be automatically deleted
      */
     data class Permanent(
-        /**
-         * The message content
-         */
-        val content: String? = null,
-        /**
-         * The message embed
-         */
-        val embed: MessageEmbed? = null
-    ) : Response() {
+        override val content: String? = null,
+        override val embed: MessageEmbed? = null
+    ) : MessageResponse() {
         constructor(embed: MessageEmbed) : this(null, embed)
     }
 


### PR DESCRIPTION
When Glyph responds to a message, he will now use the reply feature to indicate who invoked the response.

- This ties in nicely with Quickviews now using replies to indicate the invoker
- The reply is set to *not* ping the invoker
- If the `/quick` invocation is eventually added, this will make things more consistent looking
- Reply feature is not used in DMs because it would just be clutter there since the invoker is obvious

![image](https://user-images.githubusercontent.com/5406616/125345914-1c1fae00-e327-11eb-96ee-fe4211586cb1.png)
