### PR TITLE
Fix missing space in FA

### DIFF
--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/FurAffinityGenerator.kt
@@ -101,7 +101,7 @@ class FurAffinityGenerator : QuickviewGenerator() {
     private data class SubmissionUrlData(val submissionId: Int?, val cdnId: Int?, val username: String?)
 
     /**
-     * Attempts to find ids associated with FurAffinity submissions, if there are any
+     * Attempts to find ids associated with Fur Affinity submissions, if there are any
      */
     fun findIds(content: String): Flow<Int> =
         submissionUrlRegex.findAll(content.replace(escapedLinkRegex, "")).map {

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/Submission.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/Submission.kt
@@ -4,7 +4,7 @@
  * Glyph, a Discord bot that uses natural language instead of commands
  * powered by DialogFlow and Kotlin
  *
- * Copyright (C) 2017-2020 by Ian Moore
+ * Copyright (C) 2017-2021 by Ian Moore
  *
  * This file is part of Glyph.
  *
@@ -32,7 +32,7 @@ import org.yttr.glyph.bot.directors.messaging.SimpleDescriptionBuilder
 import java.time.Instant
 
 /**
- * A FurAffinity submission
+ * A Fur Affinity submission
  */
 @Serializable
 data class Submission(
@@ -119,7 +119,7 @@ data class Submission(
             .setAuthor(name, profile, avatar)
             .setTitle(title, link)
             .setColor(rating.color)
-            .setFooter("FurAffinity")
+            .setFooter("Fur Affinity")
             .setTimestamp(Instant.parse(postedAt))
 
         val description = SimpleDescriptionBuilder()

--- a/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/SubmissionRating.kt
+++ b/glyph-bot/src/main/kotlin/messaging/quickview/furaffinity/SubmissionRating.kt
@@ -27,7 +27,7 @@ package org.yttr.glyph.bot.messaging.quickview.furaffinity
 import java.awt.Color
 
 /**
- * The submission rating (maturity level) of a FurAffinity submission
+ * The submission rating (maturity level) of a Fur Affinity submission
  */
 enum class SubmissionRating(
     /**


### PR DESCRIPTION
Fur Affinity is spelled with a space. It was incorrectly spelled as "FurAffinity" in multiple places.

That's it. That's all I changed.