### PR TITLE
Update logback to version 1.2.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,27 @@
+/*
+ * build.gradle.kts
+ *
+ * Glyph, a Discord bot that uses natural language instead of commands
+ * powered by DialogFlow and Kotlin
+ *
+ * Copyright (C) 2017-2021 by Ian Moore
+ *
+ * This file is part of Glyph.
+ *
+ * Glyph is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
 
 /*
@@ -43,9 +67,12 @@ subprojects {
     apply(plugin = "kotlinx-serialization")
     apply(plugin = "tanvd.kosogor")
 
+    val logbackVersion: String by project.extra
+
     dependencies {
         implementation(kotlin("stdlib-jdk8", kotlinVersion))
         implementation("io.lettuce:lettuce-core:6.0.0.M1")
+        implementation("ch.qos.logback:logback-classic:$logbackVersion")
         testImplementation("org.jetbrains.kotlin:kotlin-test")
     }
 

--- a/glyph-bot/build.gradle.kts
+++ b/glyph-bot/build.gradle.kts
@@ -53,7 +53,6 @@ group = "org.yttr.glyph.bot"
 version = "1.0"
 
 internal val coroutinesVersion: String by project.extra
-internal val logbackVersion: String by project.extra
 internal val jdaVersion: String by project.extra
 internal val ktorVersion: String by project.extra
 
@@ -81,7 +80,6 @@ tasks.withType(KotlinJvmCompile::class) {
 dependencies {
     implementation(project(":glyph-shared"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutinesVersion")
-    implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("net.dv8tion:JDA:$jdaVersion")
     implementation("club.minnced:discord-webhooks:0.5.7")
     implementation("com.google.cloud:google-cloud-storage:1.106.0")

--- a/glyph-config/build.gradle.kts
+++ b/glyph-config/build.gradle.kts
@@ -1,3 +1,27 @@
+/*
+ * build.gradle.kts
+ *
+ * Glyph, a Discord bot that uses natural language instead of commands
+ * powered by DialogFlow and Kotlin
+ *
+ * Copyright (C) 2017-2021 by Ian Moore
+ *
+ * This file is part of Glyph.
+ *
+ * Glyph is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import tanvd.kosogor.proxy.shadowJar
 
 /*
@@ -27,7 +51,6 @@ import tanvd.kosogor.proxy.shadowJar
 group = "org.yttr.glyph.config"
 version = "1.0"
 
-internal val logbackVersion: String by project.extra
 internal val ktorVersion: String by project.extra
 
 shadowJar {
@@ -43,7 +66,6 @@ tasks.named("stage") {
 
 dependencies {
     implementation(project(":glyph-shared"))
-    implementation("ch.qos.logback:logback-classic:$logbackVersion")
     implementation("io.ktor:ktor-server-netty:$ktorVersion")
     implementation("io.ktor:ktor-auth:$ktorVersion")
     implementation("io.ktor:ktor-serialization:$ktorVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,6 +27,6 @@ kotlin.code.style=official
 kotlinVersion=1.5.10
 coroutinesVersion=1.5.0
 jdaVersion=4.3.0_334
-logbackVersion=1.2.1
+logbackVersion=1.2.8
 exposedVersion=0.32.1
 ktorVersion=1.6.0


### PR DESCRIPTION
Out of an abundance of caution.

Currently a successful RCE is known to require all of the following:

> 1. write access to logback.xml
> 2. use of versions < 1.2.8
> 3. reloading of poisoned configuration data, which implies application restart or scan="true" set prior to attack

Write access was never allowed.

https://jira.qos.ch/browse/LOGBACK-1591