### PR TITLE
Fix the config link in help

### DIFF
--- a/glyph-bot/src/main/resources/help.md
+++ b/glyph-bot/src/main/resources/help.md
@@ -7,7 +7,7 @@ To see what I can do, be sure to check out my **full skills list** and **suggest
 official server or via the anonymous feedback skill.
 
 [Skills List](https://gl.yttr.org/en/latest/skills.html) -
-[Configure](https://conf.gl.yttr.org/) -
+[Configure](https://gl.yttr.org/config) -
 [Join Help Server](https://gl.yttr.org/server) -
 [Invite to Server](https://gl.yttr.org/invite) -
 [Sponsor](https://gl.yttr.org/sponsor) -


### PR DESCRIPTION
conf.gl.yttr.org was a mistake because it requires paid dynos and can't be put behind Cloudflare

I'll just use the herokuapp.com link with https until I replace the website with interactions in Discord